### PR TITLE
Invert view of pedal automation has disabled.

### DIFF
--- a/Source/Core/Configuration/UserInterfaceFlags.h
+++ b/Source/Core/Configuration/UserInterfaceFlags.h
@@ -212,7 +212,7 @@ private:
     MouseWheelFlags mouseWheelFlags;
 
     float uiScaleFactor = 1.f;
-    static constexpr auto minUiScaleFactor = 1.f;
+    static constexpr auto minUiScaleFactor = 0.5f;
     static constexpr auto maxUiScaleFactor = 3.f;
 
     bool metronomeEnabled = false;

--- a/Source/UI/Pages/Settings/UserInterfaceSettings.cpp
+++ b/Source/UI/Pages/Settings/UserInterfaceSettings.cpp
@@ -254,6 +254,30 @@ UserInterfaceSettings::UserInterfaceSettings() noexcept
     this->uiScaleTitle->setBorderSize({ 0, 2, 0, 2 });
     this->uiScaleTitle->setInterceptsMouseClicks(false, false);
 
+    this->scaleUi05 = make<ToggleButton>(CharPointer_UTF8("\xc3\x97 0.5"));
+    this->addAndMakeVisible(this->scaleUi05.get());
+    this->scaleUi05->onClick = [this]()
+    {
+        BailOutChecker checker(this);
+        App::Config().getUiFlags()->setUiScaleFactor(0.5f);
+        if (!checker.shouldBailOut())
+        {
+            this->updateButtons();
+        }
+    };
+
+    this->scaleUi075 = make<ToggleButton>(CharPointer_UTF8("\xc3\x97 0.75"));
+    this->addAndMakeVisible(this->scaleUi075.get());
+    this->scaleUi075->onClick = [this]()
+    {
+        BailOutChecker checker(this);
+        App::Config().getUiFlags()->setUiScaleFactor(0.75f);
+        if (!checker.shouldBailOut())
+        {
+            this->updateButtons();
+        }
+    };
+    
     this->scaleUi1 = make<ToggleButton>(CharPointer_UTF8("\xc3\x97 1"));
     this->addAndMakeVisible(this->scaleUi1.get());
     this->scaleUi1->onClick = [this]()
@@ -317,17 +341,22 @@ UserInterfaceSettings::UserInterfaceSettings() noexcept
     this->germanNotation->setRadioGroupId(1);
     this->fixedDoNotation->setRadioGroupId(1);
 
+    this->scaleUi05->setRadioGroupId(2);
+    this->scaleUi075->setRadioGroupId(2);
     this->scaleUi1->setRadioGroupId(2);
     this->scaleUi125->setRadioGroupId(2);
     this->scaleUi15->setRadioGroupId(2);
     this->scaleUi175->setRadioGroupId(2);
     this->scaleUi2->setRadioGroupId(2);
 
-#if SIMPLIFIED_UI_SETTINGS
-    this->setSize(100, 460);
-#else
-    this->setSize(100, 675);
-#endif
+    // This size for bg panel from "UI Options" section.
+    // Change it, if you will add new parameter into "UI Options" section, else "Audio" section has will overlapped by params of this section.
+    #if SIMPLIFIED_UI_SETTINGS
+        this->setSize(100, 510);
+    #else
+        this->setSize(100, 725);
+    #endif
+    
 }
 
 UserInterfaceSettings::~UserInterfaceSettings() = default;
@@ -432,8 +461,14 @@ void UserInterfaceSettings::resized()
         this->uiScaleSeparator->getBottom() + separatorMargin + rowSpacing,
         this->getWidth() - margin2 * 2, titleSize);
 
-    this->scaleUi1->setBounds(margin2,
+    this->scaleUi05->setBounds(margin2,
         this->uiScaleTitle->getBottom() + rowSpacing, this->getWidth() - margin2 * 2, rowSize);
+
+    this->scaleUi075->setBounds(margin2,
+        this->scaleUi05->getBottom(), this->getWidth() - margin2 * 2, rowSize);
+    
+    this->scaleUi1->setBounds(margin2,
+        this->scaleUi075->getBottom(), this->getWidth() - margin2 * 2, rowSize);
 
     this->scaleUi125->setBounds(margin2,
         this->scaleUi1->getBottom(), this->getWidth() - margin2 * 2, rowSize);
@@ -446,6 +481,7 @@ void UserInterfaceSettings::resized()
 
     this->scaleUi2->setBounds(margin2,
         this->scaleUi175->getBottom(), this->getWidth() - margin2 * 2, rowSize);
+    
 }
 
 void UserInterfaceSettings::visibilityChanged()
@@ -509,6 +545,8 @@ void UserInterfaceSettings::updateButtons()
     this->highlightScalesButton->setToggleState(uiFlags->isScalesHighlightingEnabled(), dontSendNotification);
     this->animationsEnabledButton->setToggleState(uiFlags->areUiAnimationsEnabled(), dontSendNotification);
 
+    this->scaleUi05->setToggleState(uiFlags->getUiScaleFactor() == 0.5f, dontSendNotification);
+    this->scaleUi075->setToggleState(uiFlags->getUiScaleFactor() == 0.75f, dontSendNotification);    
     this->scaleUi1->setToggleState(uiFlags->getUiScaleFactor() == 1.f, dontSendNotification);
     this->scaleUi125->setToggleState(uiFlags->getUiScaleFactor() == 1.25f, dontSendNotification);
     this->scaleUi15->setToggleState(uiFlags->getUiScaleFactor() == 1.5f, dontSendNotification);

--- a/Source/UI/Pages/Settings/UserInterfaceSettings.h
+++ b/Source/UI/Pages/Settings/UserInterfaceSettings.h
@@ -58,6 +58,8 @@ private:
     UniquePointer<ToggleButton> animationsEnabledButton;
     UniquePointer<SeparatorHorizontal> uiScaleSeparator;
     UniquePointer<Label> uiScaleTitle;
+    UniquePointer<ToggleButton> scaleUi05;
+    UniquePointer<ToggleButton> scaleUi075;
     UniquePointer<ToggleButton> scaleUi1;
     UniquePointer<ToggleButton> scaleUi125;
     UniquePointer<ToggleButton> scaleUi15;

--- a/Source/UI/Sequencer/EditorPanels/AutomationEditor/AutomationStepEventComponent.cpp
+++ b/Source/UI/Sequencer/EditorPanels/AutomationEditor/AutomationStepEventComponent.cpp
@@ -58,10 +58,11 @@ void AutomationStepEventComponent::paint(Graphics &g)
     const float right = jmax(left, this->floatLocalBounds.getWidth() - r);
     const float top = r + marginTop;
     const float h = this->floatLocalBounds.getHeight() - d - marginTop - marginBottom;
-    const float y = top + (h * this->event.getControllerValue());
-    const float previousY = top + (h * (this->prevEventHolder != nullptr ?
+    
+    const float y = top + (h * (1.f - this->event.getControllerValue()));
+    const float previousY = top + (h * (1.f - (this->prevEventHolder != nullptr ?
         this->prevEventHolder->getEvent().getControllerValue() :
-        Globals::Defaults::onOffControllerState));
+        Globals::Defaults::onOffControllerState)));
 
     g.setColour(this->dotColour);
     g.fillRect(right - r, y - r + 1.f, d, d - 2.f);
@@ -70,10 +71,10 @@ void AutomationStepEventComponent::paint(Graphics &g)
     g.setColour(this->lineColour);
     if (y > previousY)
     {
-        // _
-        //  |
-        const bool compactMode =
-            this->prevEventHolder != nullptr && (this->getX() - this->prevEventHolder->getRight()) <= 0;
+
+        //  ‾|
+    
+        const bool compactMode = this->prevEventHolder != nullptr && (this->getX() - this->prevEventHolder->getRight()) <= 0;
 
         const auto offset = compactMode ? d : 0.f;
         g.fillRect(right, previousY + offset, 1.f, y - previousY - d - offset);
@@ -81,10 +82,10 @@ void AutomationStepEventComponent::paint(Graphics &g)
     }
     else if (previousY > y)
     {
+
         // _|
-        const bool compactMode =
-            (this->prevEventHolder != nullptr && (this->getX() - this->prevEventHolder->getRight()) <= 0) ||
-            (this->nextEventHolder != nullptr && (this->nextEventHolder->getX() - this->getRight()) <= 0);
+
+        const bool compactMode = (this->prevEventHolder != nullptr && (this->getX() - this->prevEventHolder->getRight()) <= 0) || (this->nextEventHolder != nullptr && (this->nextEventHolder->getX() - this->getRight()) <= 0);
 
         g.fillRect(right, y + d, 1.f, previousY - y - d - (compactMode ? d : 0.f));
         g.drawHorizontalLine(roundToInt(previousY), left, compactMode ? right - r : right);

--- a/Source/UI/Sequencer/EditorPanels/AutomationEditor/AutomationStepEventsConnector.cpp
+++ b/Source/UI/Sequencer/EditorPanels/AutomationEditor/AutomationStepEventsConnector.cpp
@@ -78,7 +78,7 @@ void AutomationStepEventsConnector::resizeToFit(float newControllerValue)
     }
 
     const float h = y2 - d - marginTop - marginBottom;
-    const float y = r + marginTop + (h * this->eventControllerValue);
+    const float y = r + marginTop + (h * (1.f - this->eventControllerValue));
 
     this->realBounds = { jmin(x1, x2) + r, y, fabsf(x1 - x2), y2 - y };
 


### PR DESCRIPTION
[Invert view of pedal automation has disabled.](https://github.com/helio-fm/helio-sequencer/pull/379/commits/63ebb6a4aeb4eb37780c675e8fc11adf8e4ef2f1): Это невозможно больше терпеть!

[Added negative UI sizes.](https://github.com/helio-fm/helio-sequencer/pull/379/commits/ba60ee31f9549fd24a3b3c7fa0ba4ad7e4e8f5ed): Я там поменял размеры бекграунд панели для ПК, но у меня нет под рукой Andorid телефона, чтобы посмотреть как настройки выглядят там, как бы там нибыло, всем добавил к предыдущему размеру 50. Мне тяжело на iPhone 13 пользоваться аппкой, даже пианоролл весь не входит на 1x, а это проверю, когда деплойните в AppStore.